### PR TITLE
Misc Updates - data scrub, DCompose ver, packages, Ethernet dev ID, Vagrant 16.04

### DIFF
--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "ubuntu/xenial64"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -22,5 +22,11 @@
         name: docker
         state: restarted
 
+    - name: Install make
+      apt:
+        name: make
+        state: present
+        update_cache: yes
+
     - name: Fire up containers
       command: chdir=/hdc/endpoint make deploy

--- a/ansible/docker.yml
+++ b/ansible/docker.yml
@@ -56,15 +56,7 @@
         regexp: '^start on'
         replace: '#start on'
 
-    - name: Install Docker Compose (Xenial/16.04)
-      when: ansible_distribution_release == 'xenial'
-      apt:
-        name: docker-compose
-        state: present
-        update_cache: yes
-
-    - name: Install Docker Compose (Trusty/14.04)
-      when: ansible_distribution_release == 'trusty'
+    - name: Install Docker Compose
       shell: |
         LIST=$( git ls-remote https://github.com/docker/compose | grep "refs/tags" | grep -oP "[0-9]+(\.[0-9]+)+$" )
         while [ $( echo "${LIST}" | grep -v "^$" | wc -l ) -gt 0 ]

--- a/ansible/encrypt.yml
+++ b/ansible/encrypt.yml
@@ -11,7 +11,11 @@
   tasks:
     - stat:
         path: /home/vagrant/.bashrc
-      register: vagrantcheck
+      register: vagrantcheckuser
+
+    - stat:
+        path: /vagrant/
+      register: vagrantcheckdir
 
     - stat:
         path: /usr/bin/docker
@@ -54,7 +58,8 @@
 
     - name: Create encrypted mount
       when:
-        - vagrantcheck.stat.exists == False
+        - vagrantcheckuser.stat.exists == False
+        - vagrantcheckdir.stat.exists == False
       expect:
         creates: /hdc/.data/.encfs6.xml
         echo: yes

--- a/hdc/Makefile
+++ b/hdc/Makefile
@@ -135,13 +135,15 @@ firewall: packages
 # Set and maintain static IP, from config.env
 ip:
 	. ../config.env; \
+	ETHER_DEV=$$( ip -o link show | grep -v 'vbox\|veth\|br-' | awk '{print $$2,$$9}' | grep UP | awk '{print $$1}' | \
+		sed 's/://' | head -n1 ); \
 	if( ! sudo crontab -l | grep "ip addr add" ); \
 	then \
 		( \
 			sudo crontab -l; \
 			echo ""; \
 			echo "# Keep Static IP Active"; \
-			echo "0 * * * * ip addr add $${IP_STATIC} dev eth0"; \
+			echo "0 * * * * ip addr add $${IP_STATIC} dev $${ETHER_DEV}"; \
 		) | sudo crontab -; \
 	fi
 

--- a/hdc/Makefile
+++ b/hdc/Makefile
@@ -150,7 +150,7 @@ ip:
 
 # Packages - TODO: switch to apt (not apt-get) when Ubuntu 14.04 is dropped
 packages:
-	@	PACKAGES="autossh encfs lynx monit nano parted python realpath secure-delete sysstat ufw"; \
+	@	PACKAGES="autossh encfs lynx monit nano parted python realpath secure-delete sysstat traceroute ufw"; \
 		MISSING=0; \
 		for p in $${PACKAGES}; \
 		do \

--- a/hdc/Makefile
+++ b/hdc/Makefile
@@ -148,7 +148,7 @@ ip:
 
 # Packages - TODO: switch to apt (not apt-get) when Ubuntu 14.04 is dropped
 packages:
-	@	PACKAGES="autossh encfs lynx monit nano parted python realpath sysstat ufw"; \
+	@	PACKAGES="autossh encfs lynx monit nano parted python realpath secure-delete sysstat ufw"; \
 		MISSING=0; \
 		for p in $${PACKAGES}; \
 		do \
@@ -209,10 +209,22 @@ user:
 		fi
 
 
+# Scrub folder, if specified in config.env
+scrub: packages
+	@	sudo service docker stop || true
+	@	. ../config.env; \
+		( ! sudo grep --quiet "$${MOUNT_DEV}" /proc/mounts )|| \
+			sudo umount "$${MOUNT_DEV}"; \
+		( ! sudo grep --quiet "$${MOUNT_HDD}" /proc/mounts )|| \
+			sudo umount "$${MOUNT_HDD}"; \
+		[ -z "$${VOLS_DATA}" ]|| \
+			sudo srm -rfll $${VOLS_DATA}
+
+
 # Scrub external HDD, if specified in config.env
-scrub:
-		sudo service docker stop || true
-		. ../config.env; \
+scrub-dev:
+	@	sudo service docker stop || true
+	@	. ../config.env; \
 		( ! sudo grep --quiet "$${MOUNT_DEV}" /proc/mounts )|| \
 			sudo umount "$${MOUNT_DEV}"; \
 		( ! sudo grep --quiet "$${MOUNT_HDD}" /proc/mounts )|| \

--- a/hdc/decrypt.sh
+++ b/hdc/decrypt.sh
@@ -102,9 +102,7 @@ fi
 
 # Get Ethernet device name (filtered and keeping only one result)
 #
-ETHER_DEV="$( ifconfig | grep 'encap:Ethernet' | grep -v 'docker\|veth' | awk '{print $1}' )"
-set -- "${ETHER_DEV}"
-ETHER_DEV="${1}"
+ETHER_DEV=$( ip -o link show | grep -v 'vbox\|veth\|br-' | awk '{print $2,$9}' | grep UP | awk '{print $1}' | sed 's/://' | head -n1 ); \
 
 
 # Static IP - if vars set, Eth dev ID'd and not already is use


### PR DESCRIPTION
- Packages (traceroute, secure-delete, make)
- Improve identification of Ethernet device name
- Upgrade (+fixes) to use Ubuntu 16.04 as Vagrant VM
- Improve Vagrant check (simplified steps)
- Use same Docker Compose install (more up to date) for 16.04 and 14.04
- Default data scrub by the folder, not just the device (still available)